### PR TITLE
fix: :rotating_light: 전역으로 선언되어 있던 text-align 삭제

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,6 @@
 * {
 	box-sizing: border-box;
 	font-family: 'Noto Sans', sans-serif;
-	text-align: initial;
 }
 
 #root {


### PR DESCRIPTION
전역에 설정되어 있던 text-align 삭제로 인해 다른 컴포넌트들에 text-align을 직접 설정해줘야 합니다 확인부탁드려요~