### PR TITLE
feat: :sparkles: 컴포넌트 구조 변경 및 DatePicker 도입

### DIFF
--- a/src/components/Input/InputContainer.tsx
+++ b/src/components/Input/InputContainer.tsx
@@ -1,7 +1,9 @@
 import CategorySelect from '@/components/Input/components/CategorySelect'
+import DatePickerField from '@/components/Input/components/DatePickerField'
 import InputField from '@/components/Input/components/InputField'
 import InputForm from '@/components/Input/components/InputForm'
 import InputTypeToggle from '@/components/Input/components/InputTypeToggle'
+import TextAreaField from '@/components/Input/components/TextAreaField'
 import { incomeCategories } from '@/constants/categories'
 import { IInputFormData } from '@/types/type'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -17,6 +19,7 @@ const InputContainer = () => {
 			memo: '',
 		},
 	})
+
 	return (
 		<FormProvider {...methods}>
 			<div className='relative flex flex-col gap-6 w-full min-w-auto tablet:min-w-[320px] tablet:flex-col bg-gray-50 rounded-[3rem] shadow-2xl'>
@@ -36,8 +39,8 @@ const InputContainer = () => {
 						</div>
 
 						<div className='flex flex-col flex-1'>
-							<InputField label='사용한 날짜' type='date' name='date' />
-							<InputField label='메모' tagName='textarea' name='memo' />
+							<DatePickerField label='날짜' name='date' />
+							<TextAreaField label='메모' name='memo' />
 						</div>
 					</div>
 				</InputForm>

--- a/src/components/Input/components/BaseField.tsx
+++ b/src/components/Input/components/BaseField.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+interface IBaseFieldProps {
+	label: string
+	unit?: string
+	children: React.ReactNode
+}
+
+const BaseField = ({ label, unit, children }: IBaseFieldProps) => {
+	return (
+		<div className={`flex flex-col mb-11 ${label === '메모' && 'flex-1'}`}>
+			{/* 라벨 영역 */}
+			<div className='flex justify-between items-center mb-2'>
+				<label className='text-2xl font-medium ml-0.5'>{label}</label>
+				{unit && <label>({unit})</label>}
+			</div>
+			{/* 입력 content */}
+			<div
+				className={`relative flex rounded-[15px] w-full bg-[#F7F7F8] shadow-analyze-box tablet:flex-row flex-1`}
+			>
+				{children}
+			</div>
+		</div>
+	)
+}
+
+export default BaseField

--- a/src/components/Input/components/DatePickerField.tsx
+++ b/src/components/Input/components/DatePickerField.tsx
@@ -1,0 +1,47 @@
+import BaseField from '@/components/Input/components/BaseField'
+import { IInputFormData } from '@/types/type'
+import { DatePick } from '@/utils/DatePick'
+import { useController, useFormContext } from 'react-hook-form'
+
+interface DatePickerFieldProps {
+	label: string
+	name: keyof IInputFormData
+}
+
+const DatePickerField = ({ label, name }: DatePickerFieldProps) => {
+	const { control } = useFormContext<IInputFormData>()
+
+	const {
+		field: { value, onChange },
+	} = useController({
+		name,
+		control,
+	})
+
+	const selectedDate = (() => {
+		if (typeof value === 'string') {
+			return new Date(value)
+		}
+		return new Date()
+	})()
+
+	const onSelect = (date: Date | null) => {
+		if (!date) {
+			alert('날짜를 선택해주세요.')
+			return
+		}
+		onChange(date.toLocaleString('sv').slice(0, 10))
+	}
+
+	return (
+		<BaseField label={label}>
+			<div className='text-xl px-5 w-full h-16 rounded-[15px] focus:ring-2 focus:ring-inset focus:ring-[#5FB1FF] focus:outline-none bg-transparent flex items-center'>
+				<div className='flex-1'>
+					<DatePick selectedDate={selectedDate} handleSelect={onSelect} />
+				</div>
+			</div>
+		</BaseField>
+	)
+}
+
+export default DatePickerField

--- a/src/components/Input/components/InputField.tsx
+++ b/src/components/Input/components/InputField.tsx
@@ -1,55 +1,26 @@
+import BaseField from '@/components/Input/components/BaseField'
 import { IInputFormData } from '@/types/type'
-import * as React from 'react'
 import { useFormContext } from 'react-hook-form'
 
-interface IInputFieldProps
-	extends React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
+interface IInputFieldProps {
 	label: string
 	unit?: string
 	type?: string
-	tagName?: 'input' | 'textarea'
 	name: keyof IInputFormData
 }
 
-const InputField = ({
-	label,
-	unit,
-	type = 'text',
-	tagName,
-	name,
-}: IInputFieldProps) => {
+const InputField = ({ label, unit, type = 'text', name }: IInputFieldProps) => {
 	const { register } = useFormContext<IInputFormData>()
 
 	return (
-		<div
-			className={`flex flex-col mb-11 ${tagName === 'textarea' && 'flex-1'}`}
-		>
-			{/* 라벨 영역 */}
-			<div className='flex justify-between items-center mb-2'>
-				<label className='text-2xl font-medium ml-0.5'>{label}</label>
-				{unit && <label>({unit})</label>}
-			</div>
-			<div
-				className={`relative flex rounded-[15px] w-full bg-[#F7F7F8] shadow-analyze-box tablet:flex-row flex-1`}
-			>
-				{/* tagName에 따른 input, textarea 출력 */}
-				{tagName === 'textarea' ? (
-					<textarea
-						className='text-xl px-5 py-5 w-full rounded-[15px] focus:ring-2 focus:ring-inset focus:ring-[#5FB1FF] focus:outline-none bg-transparent'
-						{...register(name)}
-					/>
-				) : (
-					<input
-						type={type}
-						className='text-xl px-5 w-full h-16 rounded-[15px] focus:ring-2 focus:ring-inset focus:ring-[#5FB1FF] focus:outline-none bg-transparent'
-						{...register(name)}
-					/>
-				)}
-			</div>
-		</div>
+		<BaseField label={label} unit={unit}>
+			<input
+				type={type}
+				className='text-xl px-5 w-full h-16 rounded-[15px] focus:ring-2 focus:ring-inset focus:ring-[#5FB1FF] focus:outline-none bg-transparent'
+				{...register(name)}
+			/>
+		</BaseField>
 	)
 }
-
-InputField.displayName = 'InputField'
 
 export default InputField

--- a/src/components/Input/components/InputTypeToggle.tsx
+++ b/src/components/Input/components/InputTypeToggle.tsx
@@ -48,6 +48,4 @@ const InputTypeToggle = ({ name }: ITypeToggleProps) => {
 	)
 }
 
-InputTypeToggle.displayName = 'InputTypeToggle'
-
 export default InputTypeToggle

--- a/src/components/Input/components/TextAreaField.tsx
+++ b/src/components/Input/components/TextAreaField.tsx
@@ -1,0 +1,22 @@
+import BaseField from '@/components/Input/components/BaseField'
+import { IInputFormData } from '@/types/type'
+import { useFormContext } from 'react-hook-form'
+
+interface TextAreaFieldProps {
+	label: string
+	name: keyof IInputFormData
+}
+
+const TextAreaField = ({ label, name }: TextAreaFieldProps) => {
+	const { register } = useFormContext<IInputFormData>()
+	return (
+		<BaseField label={label}>
+			<textarea
+				className='text-xl px-5 py-5 w-full rounded-[15px] focus:ring-2 focus:ring-inset focus:ring-[#5FB1FF] focus:outline-none bg-transparent'
+				{...register(name)}
+			/>
+		</BaseField>
+	)
+}
+
+export default TextAreaField


### PR DESCRIPTION
BaseInput (라벨 및 field 컨테이너), 나머지 아토믹으로 분리

### 🔥 변경 사항
- **BaseField** : 라벨을 붙이고 자식 자식 요소를 렌더링하는 컴포넌트 (라벨 및 컨테이너라고 생각)
- **InputField** : 기존의 `textarea`와 `input` 분기를 통해 렌더링하는 다수 책임이 있어, input 태그 요소들만 렌더링하도록 변경
- **TextAreaField** : 위의 문제를 해결하고자 따로 컴포넌트 분리
- **DatePickerField** : 선택한 날짜 상태를 관리하기 위해 컴포넌트 분리. DatePick을 렌더링함.

전체적으로 supabase에 저장되는 것도 확인하였으나, 리뷰자 로컬에서도 테스트하길 권장합니다.